### PR TITLE
added release-stack and logo of AnyViz cloud adapter

### DIFF
--- a/logos/anyviz.svg
+++ b/logos/anyviz.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg4325"
+   viewBox="0 0 637.79528 513.77952"
+   height="145mm"
+   width="180mm">
+  <defs
+     id="defs4327" />
+  <metadata
+     id="metadata4330">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-538.58269)"
+     id="layer1">
+    <path
+       id="path4495-7-9-6-6"
+       d="M 483.53301,930.6606 C 551.96349,930.66021 607.43704,877.31657 607.43686,811.51399 607.40036,749.76134 558.30342,698.27 494.32887,692.88911 469.67273,621.30473 403.3635,573.35904 328.89494,573.26996 c -63.62047,0.0283 -122.24551,35.12512 -153.23175,91.73034 -3.50072,-0.30756 -7.01231,-0.48048 -10.5267,-0.51814 -74.598216,-4.6e-4 -135.072494,59.5851 -135.073344,133.08838 -1.8e-4,73.50397 60.474378,133.09052 135.073344,133.09006"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#6b8192;stroke-width:35.43307114;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4058-7-1-9-3"
+       d="M 306.47864,968.27309 245.72739,838.72408 199.10204,930.7849 h -29.53261"
+       style="fill:none;stroke:#2196f3;stroke-width:35.43307114;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#ffbd54;stroke-width:35.43307114;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 340.01628,892.9792 60.75124,129.549 46.62535,-92.06103 h 29.53262"
+       id="path4516-90-3-6-4" />
+  </g>
+</svg>

--- a/stacks/anyviz/rel/1.0/docker-compose.yml
+++ b/stacks/anyviz/rel/1.0/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "2"
+services:
+  cloudadapter:
+    image: anyviz/cloudadapter
+    restart: always
+    container_name: anyviz
+    ports:
+      - "8888:8888"
+    volumes:
+      - anyviz_config:/etc/anyviz
+    # required if AnyViz VPN is needed
+    network_mode: "host"
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+volumes:
+  anyviz_config:


### PR DESCRIPTION
this is a request for adding the [universal cloud adapter](https://hub.docker.com/r/anyviz/cloudadapter) of [AnyViz ](https://www.anyviz.io/) to the app templates. 